### PR TITLE
Improve minikube deployment

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -316,6 +316,30 @@ setupServices()
 #
 ##############################################################################
 
+deployServices()
+{
+  # Check specific dependencies
+  type kubectl >/dev/null 2>&1 || { echo >&2 "ERROR: You do not have 'K8S CLI' installed.
+  Check the documentation of how to install it: https://kubernetes.io/docs/tasks/tools/install-kubectl/"; exit 1; }
+
+  # check if service folder exists inside of application's folder
+  if [ ! -d YourApplication/services ]; then
+    MSG="The application folder \"YourApplication/services\" doesn't exist"
+    print_message "error" "$MSG"
+  fi
+
+  (
+  cd "YourApplication/services" || return
+  # loop through all services and build their images
+  ls | while IFS= read -r service
+  do
+    # deploy to kubectl
+    cleanedService=$(echo "$service" | tr "[:punct:]" -)
+    kubectl run $cleanedService --image=$cleanedService --image-pull-policy=Never -n buildly
+  done
+  )
+}
+
 deployBuildlyCore()
 {
   if [ ! -d helm-charts/ ]; then

--- a/init.sh
+++ b/init.sh
@@ -413,11 +413,13 @@ deploy2Minikube()
   # start mini kube if not already
   setupMinikube
 
-  # deploy buildly using helm charts
-  deployBuildlyCore
-
-  # build local images for each service
+  # build images for each service and buildly core
+  setupServices "buildly"
   setupServices
+
+  # deploy buildly and services to a minikube instance
+  deployBuildlyCore "minikube"
+  deployServices
 }
 
 deploy2Docker()

--- a/init.sh
+++ b/init.sh
@@ -347,7 +347,7 @@ deployBuildlyCore()
   fi
   # create buildly namespace
   kubectl create namespace buildly || print_message "warn" "Namespace \"buildly\" already exists"
-  echo "Configure your buildly core to connect to a Database..."
+  echo "${BOLD}${WHITE}Configure your Buildly Core to connect to a Database...${OFF}"
   echo -n "Enter host name or IP: "
   read dbhost
   echo -n "Enter Database Port: "
@@ -361,7 +361,8 @@ deployBuildlyCore()
   setupHelm
   cd "helm-charts/buildly-core-chart" || return
   # install to minikube via helm
-  if [ -n "$1" ] && [ "$1" == "GCP" ] ;then
+  if [[ -n "$1" && ("$1" == "GCP" || "$1" == "gcp") ]] ;then
+    # TODO: Ask user if he/she is using CloudSQL for buildly core
     echo -n "${BOLD}${WHITE}What's the name of the CloudSQL instance? ${OFF}"
     read cloudsql_name
 
@@ -388,6 +389,15 @@ deployBuildlyCore()
     --set gcp.cloudsql.project_id="$cloudsql_project" \
     --set gcp.cloudsql.region="$cloudsql_region" \
     --set gcp.cloudsql.secretName="$cloudsql_secret"
+  elif [[ -n "$1" && ("$1" == "minikube" || "$1" == "Minikube") ]] ;then
+    helm install buildly-core . --namespace buildly \
+    --set configmap.data.DATABASE_HOST="$dbhost" \
+    --set configmap.data.DATABASE_PORT=\""$dbport"\" \
+    --set secret.data.DATABASE_USER="$dbuser" \
+    --set secret.data.DATABASE_PASSWORD="$dbpass" \
+    --set buildly.image.repository=buildly-core \
+    --set buildly.image.version=latest \
+    --set buildly.image.pullPolicy=IfNotPresent
   else
     helm install . --name buildly-core --namespace buildly \
     --set configmap.data.DATABASE_HOST="$dbhost" \


### PR DESCRIPTION
## Purpose
Add some functionalities:
- Update the setupService function to build Buildly Core locally when deploying to a minikube instance, so it will use the cloned and configured Buildly Core
- Create a separate function to deploy services to a minikube instance, so the build and deployment are done in different steps
- Update the method called deployBuildlyCore to use the local built Buildly Core when deploying to a minikube instance